### PR TITLE
AddCustomDomain

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notificationapi-js-client-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "NotificationAPI client-side library for JavaScript",
   "keywords": [
     "notificationapi",

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,8 +30,7 @@ const timeAgo = new TimeAgo('en-US');
 
 require('./assets/styles.css');
 
-const defaultWebSocket =
-  'wss://fp7umb7q2c.execute-api.us-east-1.amazonaws.com/dev';
+const defaultWebSocket = 'wss://ws.notificationapi.com';
 
 const notificationReqCount = 50;
 


### PR DESCRIPTION
The URL is updated. The custom domain for the WebSocket API is used. No test is updated but the new URL is locally tested. 