### PR TITLE
update notificationAPI to the latest version

### DIFF
--- a/examples/vitereactts-live/package-lock.json
+++ b/examples/vitereactts-live/package-lock.json
@@ -329,6 +329,17 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
@@ -1286,6 +1297,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/i18next": {
+      "version": "23.10.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.10.0.tgz",
+      "integrity": "sha512-/TgHOqsa7/9abUKJjdPeydoyDc0oTi/7u9F8lMSj6ufg4cbC1Oj3f/Jja7zj7WRIhEQKB7Q4eN6y68I9RDxxGQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1366,9 +1399,12 @@
       "dev": true
     },
     "node_modules/notificationapi-js-client-sdk": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/notificationapi-js-client-sdk/-/notificationapi-js-client-sdk-4.4.0.tgz",
-      "integrity": "sha512-JTLM3XpcOSJ8E1f7+UeXvAUEa62Fdhmcbuf6QbUihhQ46vqDnnMojcR7ytcosVmtaWFzaT7yvNw5/9VEgjDlsg=="
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/notificationapi-js-client-sdk/-/notificationapi-js-client-sdk-4.5.1.tgz",
+      "integrity": "sha512-/NWvHmfcSljsV8hOWIkEFmJmd263eeqMn6M69izJM+y68FqXQf8P6+zd1OmCz3Xff7ICRDJrTLcwfsJxZICbuQ==",
+      "dependencies": {
+        "i18next": "^23.9.0"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -1435,6 +1471,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/rollup": {
       "version": "4.12.0",


### PR DESCRIPTION
for testing purposes I used `    "notificationapi-js-client-sdk": "4.4.0"` and then changed it to `  "notificationapi-js-client-sdk": "*"` but this would not update the package-lock.json even you do `npm i` you have to literally remove the package from package.json download packages and add the `  "notificationapi-js-client-sdk": "*"` to the package.json